### PR TITLE
モーダルを閉じた時に要素も空になるよう修正 

### DIFF
--- a/app/javascript/packs/modal/modal_window.js
+++ b/app/javascript/packs/modal/modal_window.js
@@ -4,6 +4,11 @@ $(function () {
     });
 
     $('.js-close').click(function () {
-        $('#overlay, .modal-window, .modal-window2').fadeOut();
+        $('#overlay, .modal-window, .modal-window2').fadeOut(function(){
+            $('[name="rule"] option[value=""]').prop('selected',true);
+            $("input[type=number], number_field").val("");
+            $("input[type=datetime-local], datetime_field").val("");
+            $("input[type=text], text_field").val("");
+        });
     });
 });

--- a/app/views/events/create.js.erb
+++ b/app/views/events/create.js.erb
@@ -1,1 +1,6 @@
-$('.modal-window, .overlay').fadeOut();
+$('.modal-window, .overlay').fadeOut(function(){
+    $('[name="rule"] option[value=""]').prop('selected',true);
+    $("input[type=number], number_field").val("");
+    $("input[type=datetime-local], datetime_field").val("");
+    $("input[type=text], text_field").val("");
+});


### PR DESCRIPTION
## 概要

#33 を担当しました。


## 修正内容

以前のプルリクでは「フォームに入力した状態で閉じると次に開いた時にその内容が残っている」という問題が起こったのですが今回そちらを修正しました。

[![Image from Gyazo](https://i.gyazo.com/bf166f6de94506a82501dfd3e6f325bc.gif)](https://gyazo.com/bf166f6de94506a82501dfd3e6f325bc)

またsubmitボタンを押した場合でもリロードされないため同じ現象が起きていたためそちらも修正しました。