### PR TITLE
[WIP] レイアウトの修正

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,6 +1,8 @@
 class TopController < ApplicationController
 
-  def index; end
+  def index
+    @events = Event.all.order(start_datetime: :asc).feature_event.limit(5)
+  end
 
   def terms; end
 

--- a/app/javascript/css/top.scss
+++ b/app/javascript/css/top.scss
@@ -5,3 +5,27 @@
 .top-title {
   font-size: 6rem;
 }
+
+.event-btn {
+  font-size: 3rem;
+}
+
+.top-character-left {
+  position: fixed;
+  left: -10%;
+  bottom: -10%;
+  transform: rotate(30deg);
+  z-index: 10;
+}
+
+.top-character-right {
+  position: fixed;
+  left: 0%;
+  bottom: -15%;
+  transform: rotate(20deg);
+}
+
+// .container {
+//   position: relative;
+//   overflow: visible;
+// }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,4 +10,6 @@ class Event < ApplicationRecord
   validates :max_crews, presence: true, numericality: {only_integer: true, less_than_or_equal_to: 15} # クルーの最大人数は15人まで
   
   enum rule: { normal: 0, catch: 1, hide: 2 } #ルール属性、初期値はnoraml
+
+  scope :feature_event, -> { where("start_datetime > ?", Time.now()) }
 end

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -9,15 +9,12 @@
   </div>
   <div class="swiper-container border border-white p-3 m-3 d-inline-block">
     <div class="swiper-wrapper">
-      <div class="text-danger swiper-slide">
-        NEXT EVENT 7月12日
-      </div>
-      <div class="swiper-slide">
-        RANKING 現在のkill率1位はいずみんです！
-      </div>
-      <div class="swiper-slide">
-        RANKING 現在のkill率1位はいずみんです！
-      </div>
+      <% @events.each do |event| %>
+        <div class="text-danger swiper-slide">
+          <%= event.start_datetime.strftime('%Y/%m/%d %H:%M') %><br><br>
+          <%= event.message %>
+        </div>
+      <% end %>
     </div>
   </div>
   <div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,25 +1,35 @@
 <div class="container text-white text-center">
-  <div class="top-title amongus-font">
+  <div class="top-title amongus-font mb-5">
     @E
   </div>
   <div>
-    <div class="border-bottom border-white d-inline-block">
+    <div class="border-bottom border-white d-inline-block h3">
       information
     </div>
   </div>
-  <div class="swiper-container border border-white p-3 m-3 d-inline-block">
+  <div class="swiper-container border border-white p-3 m-3 d-inline-block mb-5 rounded">
     <div class="swiper-wrapper">
-      <% @events.each do |event| %>
+      <% @events.each_with_index do |event, i| %>
         <div class="text-danger swiper-slide">
-          <%= event.start_datetime.strftime('%Y/%m/%d %H:%M') %><br><br>
-          <%= event.message %>
+          <% if i == 0 %>
+            <p class="text-warning">
+              NEXT  EVENT
+              <%= event.start_datetime.strftime('%Y/%m/%d %H:%M') %><br><br>
+              <%= event.message %>
+            </p>
+          <% else %>
+            <%= event.start_datetime.strftime('%Y/%m/%d %H:%M') %><br><br>
+            <%= event.message %>
+          <% end %>
         </div>
       <% end %>
     </div>
   </div>
   <div>
-    <%=  link_to "EVENT", events_path, class: "btn btn-dark border-white btn-lg amongus-font" %>
+    <%=  link_to "EVENT", events_path, class: "btn btn-dark border-white btn-lg amongus-font event-btn px-5" %>
   </div>
+  <%= image_pack_tag "red_pum.png", size:"400x500", class:"top-character-left" %>
+  <%= image_pack_tag "lightgreen_plant.png", size:"350x450", class:"top-character-right" %>
 </div>
 
 <%= javascript_pack_tag "swiper" %>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -28,8 +28,8 @@
   <div>
     <%=  link_to "EVENT", events_path, class: "btn btn-dark border-white btn-lg amongus-font event-btn px-5" %>
   </div>
-  <%= image_pack_tag "red_pum.png", size:"400x500", class:"top-character-left" %>
-  <%= image_pack_tag "lightgreen_plant.png", size:"350x450", class:"top-character-right" %>
+  <%= image_pack_tag "red_pum.png", size:"300x400", class:"top-character-left" %>
+  <%= image_pack_tag "lightgreen_plant.png", size:"250x350", class:"top-character-right" %>
 </div>
 
 <%= javascript_pack_tag "swiper" %>


### PR DESCRIPTION
## 概要

- [ ] トップページのinformationに直近のイベントの日程とメッセージを表示できるようにしました。
- [ ] トップページのレイアウトを修正しました。


## 確認事項

### information
- [ ] 現在の時間以降の開始時間のイベントを5件取得してswiperで表示しています。
- [ ] 日付の下にスペースができたのでメッセージも表示できるようにしました。

### トップページのレイアウト
- [ ] トップページのレイアウトを整えました。(ボタンの大きさ、枠の角丸)
- [ ] キャラクターを配置しました。

▼ 一番直近のイベントは文字をオレンジにし、NEXT EVENTを頭につけました。
[![Image from Gyazo](https://i.gyazo.com/1c5ea635c84700784e84ff7c636a9feb.gif)](https://gyazo.com/1c5ea635c84700784e84ff7c636a9feb)
